### PR TITLE
Add script analysis config and Pester tests

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,5 @@
+@{
+    ExcludeRules = @(
+        'PSUseDeclaredVarsMoreThanAssignments'
+    )
+}

--- a/README.md
+++ b/README.md
@@ -187,3 +187,17 @@ There may be some confusion, but when using the Allowlist/Blocklist, the checkma
 ## Credits
 
 Thank you to [a60wattfish](https://github.com/a60wattfish), [abulgatz](abulgatz), [xsisbest](https://github.com/xsisbest), [Damian](https://github.com/Damian), [Vikingat-RAGE](https://github.com/Vikingat-RAGE), Reddit user [/u/GavinEke](https://github.com/GavinEke), and all of the contributors (https://github.com/Sycnex/Windows10Debloater/graphs/contributors) for the suggestions, code, changes, and fixes that you have all graciously worked hard on and shared! You all have done a fantastic job!
+
+## Development
+
+To analyze scripts with PSScriptAnalyzer:
+
+```powershell
+pwsh ./Run-ScriptAnalyzer.ps1
+```
+
+To run tests with Pester:
+
+```powershell
+pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"
+```

--- a/Run-ScriptAnalyzer.ps1
+++ b/Run-ScriptAnalyzer.ps1
@@ -1,0 +1,6 @@
+param(
+    [string]$Path = $PSScriptRoot
+)
+
+$settings = Join-Path $PSScriptRoot 'PSScriptAnalyzerSettings.psd1'
+Invoke-ScriptAnalyzer -Path $Path -Recurse -Settings $settings

--- a/tests/Debloater.Tests.ps1
+++ b/tests/Debloater.Tests.ps1
@@ -1,0 +1,24 @@
+Describe 'Debloat Windows script' {
+    It 'removes specified apps' {
+        $global:removed = @()
+        function Get-AppxPackage { param([string]$Name,[switch]$AllUsers) @([pscustomobject]@{Name='Microsoft.BingNews'}) }
+        function Get-AppxProvisionedPackage { param([switch]$Online) @([pscustomobject]@{PackageName='Microsoft.BingNews'}) }
+        function Remove-AppxPackage { param([Parameter(ValueFromPipeline=$true)]$InputObject,[switch]$AllUsers,[Parameter(ValueFromRemainingArguments=$true)]$Args) process { $global:removed += ,$InputObject } }
+        function Remove-AppxProvisionedPackage { param([Parameter(ValueFromPipeline=$true)]$InputObject,[switch]$Online,[Parameter(ValueFromRemainingArguments=$true)]$Args) process {} }
+        $debloatPath = Join-Path (Join-Path $PSScriptRoot '..') 'Individual Scripts/Debloat Windows'
+        $content = Get-Content -Path $debloatPath -Raw
+        . ([ScriptBlock]::Create($content))
+        $global:removed.Count | Should -BeGreaterThan 0
+    }
+}
+
+Describe 'Remove Bloatware RegKeys script' {
+    It 'removes bloatware registry keys' {
+        $global:keys = @()
+        function Remove-Item { param([Parameter(ValueFromPipeline=$true)]$Path,[switch]$Recurse) process { $global:keys += ,$Path } }
+        $regPath = Join-Path (Join-Path $PSScriptRoot '..') 'Individual Scripts/Remove Bloatware RegKeys'
+        $regContent = Get-Content -Path $regPath -Raw
+        . ([ScriptBlock]::Create($regContent))
+        $global:keys | Should -Contain 'HKCR:\Extensions\ContractId\Windows.BackgroundTasks\PackageId\46928bounde.EclipseManager_2.2.4.51_neutral__a5h4egax66k6y'
+    }
+}


### PR DESCRIPTION
## Summary
- add PSScriptAnalyzer configuration and runner script
- include Pester tests for app removal and registry key cleanup
- document how to run PSScriptAnalyzer and Pester

## Testing
- `pwsh -NoLogo -NoProfile -File Run-ScriptAnalyzer.ps1`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"`


------
https://chatgpt.com/codex/tasks/task_e_689652a3a1f4832b9bd934e063cee8b7