### PR TITLE
feat: backup registry keys before removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ There are 3 switch parameters in the `Windows10SysPrepDebloater.ps1` script.
 - **`-SysPrep`**, which runs the command within a function: get-appxpackage | remove-appxpackage. This is useful since some administrators need that command to run first in order for machines to be able to properly provision the apps for removal.
 
 - **`-Debloat`**, switch parameter which does as it suggests. It runs the following functions: Start-Debloat, Remove-Keys, and Protect-Privacy.
-Remove-Keys removes registry keys leftover that are associated with the bloatware apps listed above, but not removed during the Start-Debloat function.
+Remove-Keys removes registry keys leftover that are associated with the bloatware apps listed above, but not removed during the Start-Debloat function. Before deletion, each key is exported to `C:\Temp\Windows10Debloater\RegistryBackups` and can be restored with the `Restore-Keys` function.
 
 - **`-Privacy`**, adds and/or changes registry keys to stop some telemetry functions, stops Cortana from being used as your Search Index, disables "unnecessary" scheduled tasks, and more.
 

--- a/Windows10Debloater.ps1
+++ b/Windows10Debloater.ps1
@@ -162,11 +162,43 @@ Function Remove-Keys {
         #Windows Share Target
         "HKCR:\Extensions\ContractId\Windows.ShareTarget\PackageId\ActiproSoftwareLLC.562882FEEB491_2.6.18.18_neutral__24pqs290vpjk0"
     )
-        
+
+    $RegistryBackupPath = Join-Path $DebloatFolder "RegistryBackups"
+    if (!(Test-Path $RegistryBackupPath)) {
+        New-Item -Path $RegistryBackupPath -ItemType Directory | Out-Null
+    }
+    Write-Output "Exporting registry keys to $RegistryBackupPath"
+    foreach ($Key in $Keys) {
+        $safeName = ($Key -replace '[\\/:*?\"<>|]', '_') + '.reg'
+        $backupFile = Join-Path $RegistryBackupPath $safeName
+        if (Test-Path $Key) {
+            reg.exe export $Key $backupFile /y | Out-Null
+            Write-Output "Backed up $Key to $backupFile"
+        }
+        else {
+            Write-Output "Registry key $Key not found; skipping backup"
+        }
+    }
+
     #This writes the output of each key it is removing and also removes the keys listed above.
     ForEach ($Key in $Keys) {
         Write-Output "Removing $Key from registry"
         Remove-Item $Key -Recurse
+    }
+
+    Write-Output "Registry key backups saved to $RegistryBackupPath"
+}
+
+Function Restore-Keys {
+    $RegistryBackupPath = Join-Path $DebloatFolder "RegistryBackups"
+    if (Test-Path $RegistryBackupPath) {
+        Get-ChildItem -Path $RegistryBackupPath -Filter *.reg | ForEach-Object {
+            reg.exe import $_.FullName | Out-Null
+            Write-Output "Restored registry key from $($_.FullName)"
+        }
+    }
+    else {
+        Write-Output "No registry backups found at $RegistryBackupPath"
     }
 }
             


### PR DESCRIPTION
## Summary
- export registry keys to C:\Temp\Windows10Debloater\RegistryBackups before deletion
- add Restore-Keys function to re-import saved .reg files
- document backup behavior in README and init log folder for SysPrep script

## Testing
- `pwsh -NoProfile -Command "Get-Module -ListAvailable PSScriptAnalyzer | Select-Object -First 1"` *(failed: command not found)*
- `apt-get install -y powershell` *(failed: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_689652a20e3c832b897fbd26367ed64b