### PR TITLE
Add OS version guard with Force override

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Be sure to look at the Contributors' GitHubs to see if they have GitHub sponsors
 ## Disclaimer
 
 **WARNING:** I do **NOT** take responsibility for what may happen to your system! Run scripts at your own risk!
-Also, other variants of this repo are not technically "new" versions of this, but they are different in their own respective ways. There are some sites saying that other projects are "new" versions of this, but that is inaccurate. 
+Also, other variants of this repo are not technically "new" versions of this, but they are different in their own respective ways. There are some sites saying that other projects are "new" versions of this, but that is inaccurate.
+These scripts are intended for Windows 10 and check the operating system at startup. They will warn and exit on other versions unless the `-Force` switch is used.
 
 ## How To Run the Windows10Debloater.ps1 and the Windows10DebloaterGUI.ps1 files
 

--- a/Windows10Debloater.ps1
+++ b/Windows10Debloater.ps1
@@ -1,6 +1,18 @@
 #This function finds any AppX/AppXProvisioned package and uninstalls it, except for Freshpaint, Windows Calculator, Windows Store, and Windows Photos.
 #Also, to note - This does NOT remove essential system services/software/etc such as .NET framework installations, Cortana, Edge, etc.
 
+param(
+    [switch]$Force
+)
+
+$osVersion = [System.Environment]::OSVersion.Version
+if ($osVersion.Major -ne 10) {
+    Write-Warning "Detected Windows version $($osVersion). This script is intended for Windows 10."
+    if (-not $Force) {
+        return
+    }
+}
+
 #This will self elevate the script so with a UAC prompt since this script needs to be run as an Administrator in order to function properly.
 If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]'Administrator')) {
     Write-Host "You didn't run this script as an Administrator. This script will self elevate to run as an Administrator and continue."

--- a/Windows10DebloaterGUI.ps1
+++ b/Windows10DebloaterGUI.ps1
@@ -6,6 +6,18 @@ $EnableEdgePDFTakeover.Location = New-Object System.Drawing.Point(155, 260)
 
 #>
 
+param(
+    [switch]$Force
+)
+
+$osVersion = [System.Environment]::OSVersion.Version
+if ($osVersion.Major -ne 10) {
+    Write-Warning "Detected Windows version $($osVersion). This script is intended for Windows 10."
+    if (-not $Force) {
+        return
+    }
+}
+
 #This will self elevate the script so with a UAC prompt since this script needs to be run as an Administrator in order to function properly.
 
 $ErrorActionPreference = 'SilentlyContinue'

--- a/Windows10SysPrepDebloater.ps1
+++ b/Windows10SysPrepDebloater.ps1
@@ -4,8 +4,18 @@
 #This is the switch parameter for running this script as a 'silent' script, for use in MDT images or any type of mass deployment without user interaction.
 
 param (
-  [switch]$Debloat, [switch]$SysPrep
+  [switch]$Debloat,
+  [switch]$SysPrep,
+  [switch]$Force
 )
+
+$osVersion = [System.Environment]::OSVersion.Version
+if ($osVersion.Major -ne 10) {
+    Write-Warning "Detected Windows version $($osVersion). This script is intended for Windows 10."
+    if (-not $Force) {
+        return
+    }
+}
 
 Function Begin-SysPrep {
 


### PR DESCRIPTION
## Summary
- require Windows 10 by default in all main scripts
- allow bypassing version check with new `-Force` switch
- document Windows 10 requirement in README

## Testing
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File ./Windows10Debloater.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68965299d3f0832b92774188721df110