### PR TITLE
Refactor scheduled task handling

### DIFF
--- a/Individual Scripts/Protect Privacy
+++ b/Individual Scripts/Protect Privacy
@@ -1,3 +1,6 @@
+#Scheduled tasks to disable
+$ScheduledTasks = 'XblGameSaveTaskLogon','XblGameSaveTask','Consolidator','UsbCeip','DmClient','DmClientOnScenarioDownload'
+
 #Disables Windows Feedback Experience
     Write-Output "Disabling Windows Feedback Experience program"
     $Advertising = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AdvertisingInfo"
@@ -114,15 +117,10 @@
     }
     Set-ItemProperty $People  PeopleBand -Value 0 
         
-    #Disables scheduled tasks that are considered unnecessary 
+    #Disables scheduled tasks that are considered unnecessary
     Write-Output "Disabling scheduled tasks"
-    Get-ScheduledTask  XblGameSaveTaskLogon | Disable-ScheduledTask
-    Get-ScheduledTask  XblGameSaveTask | Disable-ScheduledTask
-    Get-ScheduledTask  Consolidator | Disable-ScheduledTask
-    Get-ScheduledTask  UsbCeip | Disable-ScheduledTask
-    Get-ScheduledTask  DmClient | Disable-ScheduledTask
-    Get-ScheduledTask  DmClientOnScenarioDownload | Disable-ScheduledTask
-    
+    $ScheduledTasks | ForEach-Object { Get-ScheduledTask -TaskName $_ | Disable-ScheduledTask }
+
     Write-Output "Stopping and disabling WAP Push Service"
     #Stop and disable WAP Push Service
 	Stop-Service "dmwappushservice"

--- a/Individual Scripts/Revert Changes
+++ b/Individual Scripts/Revert Changes
@@ -1,3 +1,6 @@
+#Scheduled tasks previously disabled
+$ScheduledTasks = 'XblGameSaveTaskLogon','XblGameSaveTask','Consolidator','UsbCeip','DmClient','DmClientOnScenarioDownload'
+
 #This function will revert the changes you made when running the Start-Debloat function.
         
     #This line reinstalls all of the bloatware that was removed
@@ -74,12 +77,7 @@
         
     #Re-enables scheduled tasks that were disabled when running the Debloat switch
     Write-Output "Enabling scheduled tasks that were disabled"
-    Get-ScheduledTask XblGameSaveTaskLogon | Enable-ScheduledTask 
-    Get-ScheduledTask  XblGameSaveTask | Enable-ScheduledTask 
-    Get-ScheduledTask  Consolidator | Enable-ScheduledTask 
-    Get-ScheduledTask  UsbCeip | Enable-ScheduledTask 
-    Get-ScheduledTask  DmClient | Enable-ScheduledTask 
-    Get-ScheduledTask  DmClientOnScenarioDownload | Enable-ScheduledTask 
+    $ScheduledTasks | ForEach-Object { Get-ScheduledTask -TaskName $_ | Enable-ScheduledTask }
 
     Write-Output "Re-enabling and starting WAP Push Service"
     #Enable and start WAP Push Service

--- a/Windows10Debloater.ps1
+++ b/Windows10Debloater.ps1
@@ -33,6 +33,9 @@ Start-Transcript -OutputDirectory "$DebloatFolder"
 
 Add-Type -AssemblyName PresentationCore, PresentationFramework
 
+# Scheduled tasks that will be disabled or enabled
+$ScheduledTasks = 'XblGameSaveTaskLogon','XblGameSaveTask','Consolidator','UsbCeip','DmClient','DmClientOnScenarioDownload'
+
 Function DebloatAll {
     #Removes AppxPackages
     #Credit to /u/GavinEke for a modified version of my whitelist code
@@ -287,14 +290,9 @@ Function Protect-Privacy {
         Set-ItemProperty $People -Name PeopleBand -Value 0
     }
         
-    #Disables scheduled tasks that are considered unnecessary 
+    #Disables scheduled tasks that are considered unnecessary
     Write-Output "Disabling scheduled tasks"
-    Get-ScheduledTask  XblGameSaveTaskLogon | Disable-ScheduledTask
-    Get-ScheduledTask  XblGameSaveTask | Disable-ScheduledTask
-    Get-ScheduledTask  Consolidator | Disable-ScheduledTask
-    Get-ScheduledTask  UsbCeip | Disable-ScheduledTask
-    Get-ScheduledTask  DmClient | Disable-ScheduledTask
-    Get-ScheduledTask  DmClientOnScenarioDownload | Disable-ScheduledTask
+    $ScheduledTasks | ForEach-Object { Get-ScheduledTask -TaskName $_ | Disable-ScheduledTask }
 
     Write-Output "Stopping and disabling Diagnostics Tracking Service"
     #Disabling the Diagnostics Tracking Service
@@ -463,12 +461,7 @@ Function Revert-Changes {
         
     #Re-enables scheduled tasks that were disabled when running the Debloat switch
     Write-Output "Enabling scheduled tasks that were disabled"
-    Get-ScheduledTask XblGameSaveTaskLogon | Enable-ScheduledTask 
-    Get-ScheduledTask  XblGameSaveTask | Enable-ScheduledTask 
-    Get-ScheduledTask  Consolidator | Enable-ScheduledTask 
-    Get-ScheduledTask  UsbCeip | Enable-ScheduledTask 
-    Get-ScheduledTask  DmClient | Enable-ScheduledTask 
-    Get-ScheduledTask  DmClientOnScenarioDownload | Enable-ScheduledTask 
+    $ScheduledTasks | ForEach-Object { Get-ScheduledTask -TaskName $_ | Enable-ScheduledTask }
 
     Write-Output "Re-enabling and starting WAP Push Service"
     #Enable and start WAP Push Service

--- a/Windows10DebloaterGUI.ps1
+++ b/Windows10DebloaterGUI.ps1
@@ -10,6 +10,9 @@ $EnableEdgePDFTakeover.Location = New-Object System.Drawing.Point(155, 260)
 
 $ErrorActionPreference = 'SilentlyContinue'
 
+# Scheduled tasks reused across disable and revert actions
+$ScheduledTasks = 'XblGameSaveTaskLogon','XblGameSaveTask','Consolidator','UsbCeip','DmClient','DmClientOnScenarioDownload'
+
 $Button = [System.Windows.MessageBoxButton]::YesNoCancel
 $ErrorIco = [System.Windows.MessageBoxImage]::Error
 $Ask = 'Do you want to run this as an Administrator?
@@ -868,14 +871,9 @@ $RemoveAllBloatware.Add_Click( {
             Set-ItemProperty -Path Registry::HKU\Default_User\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager -Name OemPreInstalledAppsEnabled -Value 0
             reg unload HKU\Default_User
       
-            #Disables scheduled tasks that are considered unnecessary 
+            #Disables scheduled tasks that are considered unnecessary
             Write-Host "Disabling scheduled tasks"
-            #Get-ScheduledTask -TaskName XblGameSaveTaskLogon | Disable-ScheduledTask
-            Get-ScheduledTask -TaskName XblGameSaveTask | Disable-ScheduledTask
-            Get-ScheduledTask -TaskName Consolidator | Disable-ScheduledTask
-            Get-ScheduledTask -TaskName UsbCeip | Disable-ScheduledTask
-            Get-ScheduledTask -TaskName DmClient | Disable-ScheduledTask
-            Get-ScheduledTask -TaskName DmClientOnScenarioDownload | Disable-ScheduledTask
+            $ScheduledTasks | ForEach-Object { Get-ScheduledTask -TaskName $_ | Disable-ScheduledTask }
         }
 
         Function UnpinStart {
@@ -1042,12 +1040,7 @@ $RevertChanges.Add_Click( {
         
         #Re-enables scheduled tasks that were disabled when running the Debloat switch
         Write-Host "Enabling scheduled tasks that were disabled"
-        Get-ScheduledTask XblGameSaveTaskLogon | Enable-ScheduledTask 
-        Get-ScheduledTask  XblGameSaveTask | Enable-ScheduledTask 
-        Get-ScheduledTask  Consolidator | Enable-ScheduledTask 
-        Get-ScheduledTask  UsbCeip | Enable-ScheduledTask 
-        Get-ScheduledTask  DmClient | Enable-ScheduledTask 
-        Get-ScheduledTask  DmClientOnScenarioDownload | Enable-ScheduledTask 
+        $ScheduledTasks | ForEach-Object { Get-ScheduledTask -TaskName $_ | Enable-ScheduledTask }
 
         Write-Host "Re-enabling and starting WAP Push Service"
         #Enable and start WAP Push Service
@@ -1297,14 +1290,9 @@ $DisableTelemetry.Add_Click( {
             Set-ItemProperty $People -Name PeopleBand -Value 0
         } 
         
-        #Disables scheduled tasks that are considered unnecessary 
+        #Disables scheduled tasks that are considered unnecessary
         Write-Host "Disabling scheduled tasks"
-        #Get-ScheduledTask XblGameSaveTaskLogon | Disable-ScheduledTask
-        Get-ScheduledTask XblGameSaveTask | Disable-ScheduledTask
-        Get-ScheduledTask Consolidator | Disable-ScheduledTask
-        Get-ScheduledTask UsbCeip | Disable-ScheduledTask
-        Get-ScheduledTask DmClient | Disable-ScheduledTask
-        Get-ScheduledTask DmClientOnScenarioDownload | Disable-ScheduledTask
+        $ScheduledTasks | ForEach-Object { Get-ScheduledTask -TaskName $_ | Disable-ScheduledTask }
 
         #Write-Host "Uninstalling Telemetry Windows Updates"
         #Uninstalls Some Windows Updates considered to be Telemetry. !WIP!

--- a/Windows10SysPrepDebloater.ps1
+++ b/Windows10SysPrepDebloater.ps1
@@ -7,6 +7,9 @@ param (
   [switch]$Debloat, [switch]$SysPrep
 )
 
+# Scheduled tasks to adjust during sysprep debloat
+$ScheduledTasks = 'XblGameSaveTaskLogon','XblGameSaveTask','Consolidator','UsbCeip','DmClient','DmClientOnScenarioDownload'
+
 Function Begin-SysPrep {
 
     param([switch]$SysPrep)
@@ -188,14 +191,9 @@ Function Protect-Privacy {
     Set-ItemProperty -Path Registry::HKU\Default_User\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager -Name OemPreInstalledAppsEnabled -Value 0
     reg unload HKU\Default_User
     
-    #Disables scheduled tasks that are considered unnecessary 
+    #Disables scheduled tasks that are considered unnecessary
     Write-Output "Disabling scheduled tasks"
-    #Get-ScheduledTask -TaskName XblGameSaveTaskLogon | Disable-ScheduledTask -ErrorAction SilentlyContinue
-    Get-ScheduledTask -TaskName XblGameSaveTask | Disable-ScheduledTask -ErrorAction SilentlyContinue
-    Get-ScheduledTask -TaskName Consolidator | Disable-ScheduledTask -ErrorAction SilentlyContinue
-    Get-ScheduledTask -TaskName UsbCeip | Disable-ScheduledTask -ErrorAction SilentlyContinue
-    Get-ScheduledTask -TaskName DmClient | Disable-ScheduledTask -ErrorAction SilentlyContinue
-    Get-ScheduledTask -TaskName DmClientOnScenarioDownload | Disable-ScheduledTask -ErrorAction SilentlyContinue
+    $ScheduledTasks | ForEach-Object { Get-ScheduledTask -TaskName $_ | Disable-ScheduledTask -ErrorAction SilentlyContinue }
 }
 
 #This includes fixes by xsisbest


### PR DESCRIPTION
## Summary
- centralize scheduled task names in a script-scoped array for reuse
- iterate over the task array to disable and re-enable tasks instead of repeating commands
- apply the same array-based approach across GUI, sysprep, and individual scripts

## Testing
- `apt-get install -y powershell` *(failed: Unable to locate package powershell)*
- `pwsh -NoProfile -Command "Get-Command"` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689652919ed4832b8c2e225082eda232