### PR TITLE
Centralize app lists in shared module

### DIFF
--- a/Individual Scripts/Clear Last Used Files and Folders.ps1
+++ b/Individual Scripts/Clear Last Used Files and Folders.ps1
@@ -1,2 +1,3 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 Write-Host "Clear last used files and folders"
 	Remove-Item %APPDATA%\Microsoft\Windows\Recent\AutomaticDestinations\*.automaticDestinations-ms -FORCE -ErrorAction SilentlyContinue

--- a/Individual Scripts/Debloat Windows
+++ b/Individual Scripts/Debloat Windows
@@ -1,57 +1,5 @@
-$AppXApps = @(
-
-        #Unnecessary Windows 10 AppX Apps
-        "*Microsoft.BingNews*"
-        "*Microsoft.GetHelp*"
-        "*Microsoft.Getstarted*"
-        "*Microsoft.Messaging*"
-        "*Microsoft.Microsoft3DViewer*"
-        "*Microsoft.MicrosoftOfficeHub*"
-        "*Microsoft.MicrosoftSolitaireCollection*"
-        "*Microsoft.NetworkSpeedTest*"
-        "*Microsoft.Office.Sway*"
-        "*Microsoft.OneConnect*"
-        "*Microsoft.People*"
-        "*Microsoft.Print3D*"
-        "*Microsoft.SkypeApp*"
-        "*Microsoft.WindowsAlarms*"
-        "*Microsoft.WindowsCamera*"
-        "*microsoft.windowscommunicationsapps*"
-        "*Microsoft.WindowsFeedbackHub*"
-        "*Microsoft.WindowsMaps*"
-        "*Microsoft.WindowsSoundRecorder*"
-        "*Microsoft.Xbox.TCUI*"
-        "*Microsoft.XboxApp*"
-        "*Microsoft.XboxGameOverlay*"
-        "*Microsoft.XboxIdentityProvider*"
-        "*Microsoft.XboxSpeechToTextOverlay*"
-        "*Microsoft.ZuneMusic*"
-        "*Microsoft.ZuneVideo*"
-
-        #Sponsored Windows 10 AppX Apps
-        #Add sponsored/featured apps to remove in the "*AppName*" format
-        "*EclipseManager*"
-        "*ActiproSoftwareLLC*"
-        "*AdobeSystemsIncorporated.AdobePhotoshopExpress*"
-        "*Duolingo-LearnLanguagesforFree*"
-        "*PandoraMediaInc*"
-        "*CandyCrush*"
-        "*Wunderlist*"
-        "*Flipboard*"
-        "*Twitter*"
-        "*Facebook*"
-        "*Spotify*"
-
-        #Optional: Typically not removed but you can if you need to for some reason
-        #"*Microsoft.Advertising.Xaml_10.1712.5.0_x64__8wekyb3d8bbwe*"
-        #"*Microsoft.Advertising.Xaml_10.1712.5.0_x86__8wekyb3d8bbwe*"
-        #"*Microsoft.BingWeather*"
-        #"*Microsoft.MSPaint*"
-        #"*Microsoft.MicrosoftStickyNotes*"
-        #"*Microsoft.Windows.Photos*"
-        #"*Microsoft.WindowsCalculator*"
-        #"*Microsoft.WindowsStore*"
-    )
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
+$AppXApps = $Bloatware
     foreach ($App in $AppXApps) {
         Write-Verbose -Message ('Removing Package {0}' -f $App)
         Get-AppxPackage -Name $App | Remove-AppxPackage -ErrorAction SilentlyContinue
@@ -61,7 +9,7 @@ $AppXApps = @(
     
     #Removes AppxPackages
     #Credit to /u/GavinEke for a modified version of my whitelist code
-    [regex]$WhitelistedApps = 'Microsoft.Paint3D|Microsoft.WindowsCalculator|Microsoft.WindowsStore|Microsoft.Windows.Photos|CanonicalGroupLimited.UbuntuonWindows|Microsoft.XboxGameCallableUI|Microsoft.XboxGamingOverlay|Microsoft.Xbox.TCUI|Microsoft.XboxGamingOverlay|Microsoft.XboxIdentityProvider|Microsoft.MicrosoftStickyNotes|Microsoft.MSPaint*'
-    Get-AppxPackage -AllUsers | Where-Object {$_.Name -NotMatch $WhitelistedApps} | Remove-AppxPackage
-    Get-AppxPackage | Where-Object {$_.Name -NotMatch $WhitelistedApps} | Remove-AppxPackage
-    Get-AppxProvisionedPackage -Online | Where-Object {$_.PackageName -NotMatch $WhitelistedApps} | Remove-AppxProvisionedPackage -Online
+    [regex]$WhitelistedAppsRegex = ($WhitelistedApps -join '|')
+    Get-AppxPackage -AllUsers | Where-Object {$_.Name -NotMatch $WhitelistedAppsRegex} | Remove-AppxPackage
+    Get-AppxPackage | Where-Object {$_.Name -NotMatch $WhitelistedAppsRegex} | Remove-AppxPackage
+    Get-AppxProvisionedPackage -Online | Where-Object {$_.PackageName -NotMatch $WhitelistedAppsRegex} | Remove-AppxProvisionedPackage -Online

--- a/Individual Scripts/Disable Cortana
+++ b/Individual Scripts/Disable Cortana
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 Write-Host "Disabling Cortana"
     $Cortana1 = "HKCU:\SOFTWARE\Microsoft\Personalization\Settings"
     $Cortana2 = "HKCU:\SOFTWARE\Microsoft\InputPersonalization"

--- a/Individual Scripts/Disable Last Used Files and Folders View.ps1
+++ b/Individual Scripts/Disable Last Used Files and Folders View.ps1
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 $Keys = @(
             
         # Deactivate showing of last used files

--- a/Individual Scripts/Enable Cortana
+++ b/Individual Scripts/Enable Cortana
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 Write-Host "Re-enabling Cortana"
     $Cortana1 = "HKCU:\SOFTWARE\Microsoft\Personalization\Settings"
     $Cortana2 = "HKCU:\SOFTWARE\Microsoft\InputPersonalization"

--- a/Individual Scripts/Enable Edge PDF
+++ b/Individual Scripts/Enable Edge PDF
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 Write-Output "Setting Edge back to default"
     $NoPDF = "HKCR:\.pdf"
     $NoProgids = "HKCR:\.pdf\OpenWithProgids"

--- a/Individual Scripts/Fix Whitelisted Apps
+++ b/Individual Scripts/Fix Whitelisted Apps
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 If (!(Get-AppxPackage -AllUsers | Select Microsoft.Paint3D, Microsoft.WindowsCalculator, Microsoft.WindowsStore, Microsoft.Windows.Photos)) {
     
         #Credit to abulgatz for these 4 lines of code

--- a/Individual Scripts/Protect Privacy
+++ b/Individual Scripts/Protect Privacy
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 #Disables Windows Feedback Experience
     Write-Output "Disabling Windows Feedback Experience program"
     $Advertising = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AdvertisingInfo"

--- a/Individual Scripts/Remove Bloatware RegKeys
+++ b/Individual Scripts/Remove Bloatware RegKeys
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 $Keys = @(
             
         #Remove Background Tasks

--- a/Individual Scripts/Revert Changes
+++ b/Individual Scripts/Revert Changes
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 #This function will revert the changes you made when running the Start-Debloat function.
         
     #This line reinstalls all of the bloatware that was removed

--- a/Individual Scripts/Set Explorers LaunchTo Computer.ps1
+++ b/Individual Scripts/Set Explorers LaunchTo Computer.ps1
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 # "This Computer"-Button starts the explorer on the following path:
 # 	LaunchTo	Value	Description
 #				1 		Computer (Harddrives, Network, etc.)

--- a/Individual Scripts/Stop Edge PDF
+++ b/Individual Scripts/Stop Edge PDF
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 #Stops edge from taking over as the default .PDF viewer    
     Write-Output "Stopping Edge from taking over as the default .PDF viewer"
     $NoPDF = "HKCR:\.pdf"

--- a/Individual Scripts/Uninstall OneDrive
+++ b/Individual Scripts/Uninstall OneDrive
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 Write-Output "Uninstalling OneDrive. Please wait."
     
     New-PSDrive  HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT

--- a/Individual Scripts/Unpin Start
+++ b/Individual Scripts/Unpin Start
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/../modules/AppLists.psm1"
 # https://superuser.com/a/1442733
 #Requires -RunAsAdministrator
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ DmClient
 These scheduled tasks that are disabled have absolutely no impact on the function of the OS.
 
 ## Bloatware that is removed
+The lists of removed and whitelisted applications are maintained in `modules/AppLists.psm1`. Update the `Bloatware` or `WhitelistedApps` arrays there to change the defaults for all scripts.
+
 
 [3DBuilder](https://www.microsoft.com/en-us/p/3d-builder/9wzdncrfj3t6),
 [ActiproSoftware](https://www.microsoft.com/en-us/p/actipro-universal-windows-controls/9wzdncrdlvzp),

--- a/Windows10Debloater.ps1
+++ b/Windows10Debloater.ps1
@@ -32,93 +32,24 @@ Else {
 Start-Transcript -OutputDirectory "$DebloatFolder"
 
 Add-Type -AssemblyName PresentationCore, PresentationFramework
+Import-Module "$PSScriptRoot/modules/AppLists.psm1"
 
 Function DebloatAll {
     #Removes AppxPackages
     #Credit to /u/GavinEke for a modified version of my whitelist code
-    $WhitelistedApps = 'Microsoft.ScreenSketch|Microsoft.Paint3D|Microsoft.WindowsCalculator|Microsoft.WindowsStore|Microsoft.Windows.Photos|CanonicalGroupLimited.UbuntuonWindows|`
-    Microsoft.XboxGameCallableUI|Microsoft.XboxGamingOverlay|Microsoft.Xbox.TCUI|Microsoft.XboxGamingOverlay|Microsoft.XboxIdentityProvider|Microsoft.MicrosoftStickyNotes|Microsoft.MSPaint|Microsoft.WindowsCamera|.NET|Framework|`
-    Microsoft.HEIFImageExtension|Microsoft.ScreenSketch|Microsoft.StorePurchaseApp|Microsoft.VP9VideoExtensions|Microsoft.WebMediaExtensions|Microsoft.WebpImageExtension|Microsoft.DesktopAppInstaller|WindSynthBerry|MIDIBerry|Slack'
+    [regex]$WhitelistedAppsRegex = ($WhitelistedApps -join '|')
     #NonRemovable Apps that where getting attempted and the system would reject the uninstall, speeds up debloat and prevents 'initalizing' overlay when removing apps
     $NonRemovable = '1527c705-839a-4832-9118-54d4Bd6a0c89|c5e2524a-ea46-4f67-841f-6a9465d9d515|E2A4F912-2574-4A75-9BB0-0D023378592B|F46D4000-FD22-4DB4-AC8E-4E1DDDE828FE|InputApp|Microsoft.AAD.BrokerPlugin|Microsoft.AccountsControl|`
     Microsoft.BioEnrollment|Microsoft.CredDialogHost|Microsoft.ECApp|Microsoft.LockApp|Microsoft.MicrosoftEdgeDevToolsClient|Microsoft.MicrosoftEdge|Microsoft.PPIProjection|Microsoft.Win32WebViewHost|Microsoft.Windows.Apprep.ChxApp|`
     Microsoft.Windows.AssignedAccessLockApp|Microsoft.Windows.CapturePicker|Microsoft.Windows.CloudExperienceHost|Microsoft.Windows.ContentDeliveryManager|Microsoft.Windows.Cortana|Microsoft.Windows.NarratorQuickStart|`
     Microsoft.Windows.ParentalControls|Microsoft.Windows.PeopleExperienceHost|Microsoft.Windows.PinningConfirmationDialog|Microsoft.Windows.SecHealthUI|Microsoft.Windows.SecureAssessmentBrowser|Microsoft.Windows.ShellExperienceHost|`
     Microsoft.Windows.XGpuEjectDialog|Microsoft.XboxGameCallableUI|Windows.CBSPreview|windows.immersivecontrolpanel|Windows.PrintDialog|Microsoft.VCLibs.140.00|Microsoft.Services.Store.Engagement|Microsoft.UI.Xaml.2.0|*Nvidia*'
-    Get-AppxPackage -AllUsers | Where-Object {$_.Name -NotMatch $WhitelistedApps -and $_.Name -NotMatch $NonRemovable} | Remove-AppxPackage
-    Get-AppxPackage | Where-Object {$_.Name -NotMatch $WhitelistedApps -and $_.Name -NotMatch $NonRemovable} | Remove-AppxPackage
-    Get-AppxProvisionedPackage -Online | Where-Object {$_.PackageName -NotMatch $WhitelistedApps -and $_.PackageName -NotMatch $NonRemovable} | Remove-AppxProvisionedPackage -Online
+    Get-AppxPackage -AllUsers | Where-Object {$_.Name -NotMatch $WhitelistedAppsRegex -and $_.Name -NotMatch $NonRemovable} | Remove-AppxPackage
+    Get-AppxPackage | Where-Object {$_.Name -NotMatch $WhitelistedAppsRegex -and $_.Name -NotMatch $NonRemovable} | Remove-AppxPackage
+    Get-AppxProvisionedPackage -Online | Where-Object {$_.PackageName -NotMatch $WhitelistedAppsRegex -and $_.PackageName -NotMatch $NonRemovable} | Remove-AppxProvisionedPackage -Online
 }
 
 Function DebloatBlacklist {
-
-    $Bloatware = @(
-
-        #Unnecessary Windows 10 AppX Apps
-        "Microsoft.BingNews"
-        "Microsoft.GetHelp"
-        "Microsoft.Getstarted"
-        "Microsoft.Messaging"
-        "Microsoft.Microsoft3DViewer"
-        "Microsoft.MicrosoftOfficeHub"
-        "Microsoft.MicrosoftSolitaireCollection"
-        "Microsoft.NetworkSpeedTest"
-        "Microsoft.News"
-        "Microsoft.Office.Lens"
-        "Microsoft.Office.OneNote"
-        "Microsoft.Office.Sway"
-        "Microsoft.OneConnect"
-        "Microsoft.People"
-        "Microsoft.Print3D"
-        "Microsoft.RemoteDesktop"
-        "Microsoft.SkypeApp"
-        "Microsoft.StorePurchaseApp"
-        "Microsoft.Office.Todo.List"
-        "Microsoft.Whiteboard"
-        "Microsoft.WindowsAlarms"
-        #"Microsoft.WindowsCamera"
-        "microsoft.windowscommunicationsapps"
-        "Microsoft.WindowsFeedbackHub"
-        "Microsoft.WindowsMaps"
-        "Microsoft.WindowsSoundRecorder"
-        "Microsoft.Xbox.TCUI"
-        "Microsoft.XboxApp"
-        "Microsoft.XboxGameOverlay"
-        "Microsoft.XboxIdentityProvider"
-        "Microsoft.XboxSpeechToTextOverlay"
-        "Microsoft.ZuneMusic"
-        "Microsoft.ZuneVideo"
-
-        #Sponsored Windows 10 AppX Apps
-        #Add sponsored/featured apps to remove in the "*AppName*" format
-        "*EclipseManager*"
-        "*ActiproSoftwareLLC*"
-        "*AdobeSystemsIncorporated.AdobePhotoshopExpress*"
-        "*Duolingo-LearnLanguagesforFree*"
-        "*PandoraMediaInc*"
-        "*CandyCrush*"
-        "*BubbleWitch3Saga*"
-        "*Wunderlist*"
-        "*Flipboard*"
-        "*Twitter*"
-        "*Facebook*"
-        "*Spotify*"
-        "*Minecraft*"
-        "*Royal Revolt*"
-        "*Sway*"
-        "*Speed Test*"
-        "*Dolby*"
-             
-        #Optional: Typically not removed but you can if you need to for some reason
-        #"*Microsoft.Advertising.Xaml_10.1712.5.0_x64__8wekyb3d8bbwe*"
-        #"*Microsoft.Advertising.Xaml_10.1712.5.0_x86__8wekyb3d8bbwe*"
-        #"*Microsoft.BingWeather*"
-        #"*Microsoft.MSPaint*"
-        #"*Microsoft.MicrosoftStickyNotes*"
-        #"*Microsoft.Windows.Photos*"
-        #"*Microsoft.WindowsCalculator*"
-        #"*Microsoft.WindowsStore*"
-    )
     foreach ($Bloat in $Bloatware) {
         Get-AppxPackage -Name $Bloat| Remove-AppxPackage
         Get-AppxProvisionedPackage -Online | Where-Object DisplayName -like $Bloat | Remove-AppxProvisionedPackage -Online

--- a/Windows10DebloaterGUI.ps1
+++ b/Windows10DebloaterGUI.ps1
@@ -36,98 +36,11 @@ If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 }
 
 
-#Unnecessary Windows 10 AppX apps that will be removed by the blacklist.
-$global:Bloatware = @(
-    "Microsoft.PPIProjection"
-    "Microsoft.BingNews"
-    "Microsoft.GetHelp"
-    "Microsoft.Getstarted"
-    "Microsoft.Messaging"
-    "Microsoft.Microsoft3DViewer"
-    "Microsoft.MicrosoftOfficeHub"
-    "Microsoft.MicrosoftSolitaireCollection"
-    "Microsoft.NetworkSpeedTest"
-    "Microsoft.News"                                    # Issue 77
-    "Microsoft.Office.Lens"                             # Issue 77
-    "Microsoft.Office.OneNote"
-    "Microsoft.Office.Sway"
-    "Microsoft.OneConnect"
-    "Microsoft.People"
-    "Microsoft.Print3D"
-    "Microsoft.RemoteDesktop"                           # Issue 120
-    "Microsoft.SkypeApp"
-    "Microsoft.StorePurchaseApp"
-    "Microsoft.Office.Todo.List"                        # Issue 77
-    "Microsoft.Whiteboard"                              # Issue 77
-    "Microsoft.WindowsAlarms"
-    "microsoft.windowscommunicationsapps"
-    "Microsoft.WindowsFeedbackHub"
-    "Microsoft.WindowsMaps"
-    "Microsoft.WindowsSoundRecorder"
-    "Microsoft.Xbox.TCUI"
-    "Microsoft.XboxApp"
-    "Microsoft.XboxGameOverlay"
-    "Microsoft.XboxGamingOverlay"
-    "Microsoft.XboxIdentityProvider"
-    "Microsoft.XboxSpeechToTextOverlay"
-    "Microsoft.ZuneMusic"
-    "Microsoft.ZuneVideo"
-
-    #Sponsored Windows 10 AppX Apps
-    #Add sponsored/featured apps to remove in the "*AppName*" format
-    "EclipseManager"
-    "ActiproSoftwareLLC"
-    "AdobeSystemsIncorporated.AdobePhotoshopExpress"
-    "Duolingo-LearnLanguagesforFree"
-    "PandoraMediaInc"
-    "CandyCrush"
-    "BubbleWitch3Saga"
-    "Wunderlist"
-    "Flipboard"
-    "Twitter"
-    "Facebook"
-    "Spotify"                                           # Issue 123
-    "Minecraft"
-    "Royal Revolt"
-    "Sway"                                              # Issue 77
-    "Dolby"                                             # Issue 78
-
-    #Optional: Typically not removed but you can if you need to for some reason
-    #"Microsoft.Advertising.Xaml_10.1712.5.0_x64__8wekyb3d8bbwe"
-    #"Microsoft.Advertising.Xaml_10.1712.5.0_x86__8wekyb3d8bbwe"
-    #"Microsoft.BingWeather"
-)
-
-#Valuable Windows 10 AppX apps that most people want to keep. Protected from DeBloat All.
-#Credit to /u/GavinEke for a modified version of my whitelist code
-$global:WhiteListedApps = @(
-    "Microsoft.WindowsCalculator"               # Microsoft removed legacy calculator
-    "Microsoft.WindowsStore"                    # Issue 1
-    "Microsoft.Windows.Photos"                  # Microsoft disabled/hid legacy photo viewer
-    "CanonicalGroupLimited.UbuntuonWindows"     # Issue 10
-    "Microsoft.Xbox.TCUI"                       # Issue 25, 91  Many home users want to play games
-    "Microsoft.XboxApp"
-    "Microsoft.XboxGameOverlay"
-    "Microsoft.XboxGamingOverlay"               # Issue 25, 91  Many home users want to play games
-    "Microsoft.XboxIdentityProvider"            # Issue 25, 91  Many home users want to play games
-    "Microsoft.XboxSpeechToTextOverlay"
-    "Microsoft.MicrosoftStickyNotes"            # Issue 33  New functionality.
-    "Microsoft.MSPaint"                         # Issue 32  This is Paint3D, legacy paint still exists in Windows 10
-    "Microsoft.WindowsCamera"                   # Issue 65  New functionality.
-    "\.NET"
-    "Microsoft.HEIFImageExtension"              # Issue 68
-    "Microsoft.ScreenSketch"                    # Issue 55: Looks like Microsoft will be axing snipping tool and using Snip & Sketch going forward
-    "Microsoft.StorePurchaseApp"                # Issue 68
-    "Microsoft.VP9VideoExtensions"              # Issue 68
-    "Microsoft.WebMediaExtensions"              # Issue 68
-    "Microsoft.WebpImageExtension"              # Issue 68
-    "Microsoft.DesktopAppInstaller"             # Issue 68
-    "WindSynthBerry"                            # Issue 68
-    "MIDIBerry"                                 # Issue 68
-    "Slack"                                     # Issue 83
-    "*Nvidia*"                                  # Issue 198
-    "Microsoft.MixedReality.Portal"             # Issue 195
-)
+Import-Module "$PSScriptRoot/modules/AppLists.psm1"
+$global:Bloatware = $Bloatware
+$global:WhiteListedApps = $WhitelistedApps
+$global:BloatwareRegex = $global:Bloatware -join '|'
+$global:WhiteListedAppsRegex = $global:WhiteListedApps -join '|'
 
 #NonRemovable Apps that where getting attempted and the system would reject the uninstall, speeds up debloat and prevents 'initalizing' overlay when removing apps
 $NonRemovables = Get-AppxPackage -AllUsers | Where-Object { $_.NonRemovable -eq $true } | ForEach { $_.Name }

--- a/Windows10SysPrepDebloater.ps1
+++ b/Windows10SysPrepDebloater.ps1
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/modules/AppLists.psm1"
 #This function finds any AppX/AppXProvisioned package and uninstalls it, except for Freshpaint, Windows Calculator, Windows Store, and Windows Photos.
 #Also, to note - This does NOT remove essential system services/software/etc such as .NET framework installations, Cortana, Edge, etc.
 
@@ -36,13 +37,11 @@ Function Start-Debloat {
 
     #Removes AppxPackages
     #Credit to Reddit user /u/GavinEke for a modified version of my whitelist code
-    [regex]$WhitelistedApps = 'Microsoft.ScreenSketch|Microsoft.Paint3D|Microsoft.WindowsCalculator|Microsoft.WindowsStore|Microsoft.Windows.Photos|CanonicalGroupLimited.UbuntuonWindows|`
-    Microsoft.MicrosoftStickyNotes|Microsoft.MSPaint|Microsoft.WindowsCamera|.NET|Framework|Microsoft.HEIFImageExtension|Microsoft.ScreenSketch|Microsoft.StorePurchaseApp|`
-    Microsoft.VP9VideoExtensions|Microsoft.WebMediaExtensions|Microsoft.WebpImageExtension|Microsoft.DesktopAppInstaller'
-    Get-AppxPackage -AllUsers | Where-Object {$_.Name -NotMatch $WhitelistedApps} | Remove-AppxPackage -ErrorAction SilentlyContinue
+    [regex]$WhitelistedAppsRegex = ($WhitelistedApps -join '|')
+    Get-AppxPackage -AllUsers | Where-Object {$_.Name -NotMatch $WhitelistedAppsRegex} | Remove-AppxPackage -ErrorAction SilentlyContinue
     # Run this again to avoid error on 1803 or having to reboot.
-    Get-AppxPackage -AllUsers | Where-Object {$_.Name -NotMatch $WhitelistedApps} | Remove-AppxPackage -ErrorAction SilentlyContinue
-    $AppxRemoval = Get-AppxProvisionedPackage -Online | Where-Object {$_.PackageName -NotMatch $WhitelistedApps} 
+    Get-AppxPackage -AllUsers | Where-Object {$_.Name -NotMatch $WhitelistedAppsRegex} | Remove-AppxPackage -ErrorAction SilentlyContinue
+    $AppxRemoval = Get-AppxProvisionedPackage -Online | Where-Object {$_.PackageName -NotMatch $WhitelistedAppsRegex} 
     ForEach ( $App in $AppxRemoval) {
     
         Remove-AppxProvisionedPackage -Online -PackageName $App.PackageName 

--- a/modules/AppLists.psm1
+++ b/modules/AppLists.psm1
@@ -1,0 +1,98 @@
+# Shared application lists for Windows10Debloater scripts.
+
+$Bloatware = @(
+    # Unnecessary Windows 10 AppX apps that will be removed by the blacklist.
+    "Microsoft.PPIProjection"
+    "Microsoft.BingNews"
+    "Microsoft.GetHelp"
+    "Microsoft.Getstarted"
+    "Microsoft.Messaging"
+    "Microsoft.Microsoft3DViewer"
+    "Microsoft.MicrosoftOfficeHub"
+    "Microsoft.MicrosoftSolitaireCollection"
+    "Microsoft.NetworkSpeedTest"
+    "Microsoft.News"                                    # Issue 77
+    "Microsoft.Office.Lens"                             # Issue 77
+    "Microsoft.Office.OneNote"
+    "Microsoft.Office.Sway"
+    "Microsoft.OneConnect"
+    "Microsoft.People"
+    "Microsoft.Print3D"
+    "Microsoft.RemoteDesktop"                           # Issue 120
+    "Microsoft.SkypeApp"
+    "Microsoft.StorePurchaseApp"
+    "Microsoft.Office.Todo.List"                        # Issue 77
+    "Microsoft.Whiteboard"                              # Issue 77
+    "Microsoft.WindowsAlarms"
+    "microsoft.windowscommunicationsapps"
+    "Microsoft.WindowsFeedbackHub"
+    "Microsoft.WindowsMaps"
+    "Microsoft.WindowsSoundRecorder"
+    "Microsoft.Xbox.TCUI"
+    "Microsoft.XboxApp"
+    "Microsoft.XboxGameOverlay"
+    "Microsoft.XboxGamingOverlay"
+    "Microsoft.XboxIdentityProvider"
+    "Microsoft.XboxSpeechToTextOverlay"
+    "Microsoft.ZuneMusic"
+    "Microsoft.ZuneVideo"
+
+    # Sponsored Windows 10 AppX Apps
+    # Add sponsored/featured apps to remove in the "*AppName*" format
+    "EclipseManager"
+    "ActiproSoftwareLLC"
+    "AdobeSystemsIncorporated.AdobePhotoshopExpress"
+    "Duolingo-LearnLanguagesforFree"
+    "PandoraMediaInc"
+    "CandyCrush"
+    "BubbleWitch3Saga"
+    "Wunderlist"
+    "Flipboard"
+    "Twitter"
+    "Facebook"
+    "Spotify"                                           # Issue 123
+    "Minecraft"
+    "Royal Revolt"
+    "Sway"                                              # Issue 77
+    "Dolby"                                             # Issue 78
+
+    # Optional: Typically not removed but you can if you need to for some reason
+    # "Microsoft.Advertising.Xaml_10.1712.5.0_x64__8wekyb3d8bbwe"
+    # "Microsoft.Advertising.Xaml_10.1712.5.0_x86__8wekyb3d8bbwe"
+    # "Microsoft.BingWeather"
+)
+
+$WhitelistedApps = @(
+    # Valuable Windows 10 AppX apps that most people want to keep. Protected from DeBloat All.
+    "Microsoft.WindowsCalculator"               # Microsoft removed legacy calculator
+    "Microsoft.WindowsStore"                    # Issue 1
+    "Microsoft.Windows.Photos"                  # Microsoft disabled/hid legacy photo viewer
+    "CanonicalGroupLimited.UbuntuonWindows"     # Issue 10
+    "Microsoft.Xbox.TCUI"                       # Issue 25, 91  Many home users want to play games
+    "Microsoft.XboxApp"
+    "Microsoft.XboxGameOverlay"
+    "Microsoft.XboxGamingOverlay"               # Issue 25, 91  Many home users want to play games
+    "Microsoft.XboxIdentityProvider"            # Issue 25, 91  Many home users want to play games
+    "Microsoft.XboxSpeechToTextOverlay"
+    "Microsoft.MicrosoftStickyNotes"            # Issue 33  New functionality.
+    "Microsoft.MSPaint"                         # Issue 32  This is Paint3D, legacy paint still exists in Windows 10
+    "Microsoft.Paint3D"
+    "Microsoft.WindowsCamera"                   # Issue 65  New functionality.
+    ".NET"
+    "Framework"
+    "Microsoft.HEIFImageExtension"              # Issue 68
+    "Microsoft.ScreenSketch"                    # Issue 55: Looks like Microsoft will be axing snipping tool and using Snip & Sketch going forward
+    "Microsoft.StorePurchaseApp"                # Issue 68
+    "Microsoft.VP9VideoExtensions"              # Issue 68
+    "Microsoft.WebMediaExtensions"              # Issue 68
+    "Microsoft.WebpImageExtension"              # Issue 68
+    "Microsoft.DesktopAppInstaller"             # Issue 68
+    "WindSynthBerry"                            # Issue 68
+    "MIDIBerry"                                 # Issue 68
+    "Slack"                                     # Issue 83
+    "*Nvidia*"                                  # Issue 198
+    "Microsoft.MixedReality.Portal"             # Issue 195
+    "Microsoft.XboxGameCallableUI"
+)
+
+Export-ModuleMember -Variable Bloatware, WhitelistedApps


### PR DESCRIPTION
## Summary
- add AppLists module exporting common Bloatware and WhitelistedApps arrays
- import shared lists across debloater scripts and individual utilities
- document centralized list maintenance in README

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(failed: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689650568810832bbedcda25ec405b3b