### PR TITLE
Add Pester test for DebloatAll

### DIFF
--- a/tests/DebloatAll.Tests.ps1
+++ b/tests/DebloatAll.Tests.ps1
@@ -1,0 +1,32 @@
+Describe 'DebloatAll' {
+    BeforeAll {
+        function DebloatAll {
+            $WhitelistedApps = 'Microsoft.WindowsCalculator'
+            $NonRemovable = 'DoNotMatch'
+            Get-AppxPackage -AllUsers | Where-Object { $_.Name -NotMatch $WhitelistedApps -and $_.Name -NotMatch $NonRemovable } | Remove-AppxPackage
+            Get-AppxPackage | Where-Object { $_.Name -NotMatch $WhitelistedApps -and $_.Name -NotMatch $NonRemovable } | Remove-AppxPackage
+            Get-AppxProvisionedPackage -Online | Where-Object { $_.PackageName -NotMatch $WhitelistedApps -and $_.PackageName -NotMatch $NonRemovable } | Remove-AppxProvisionedPackage -Online
+        }
+        function Get-AppxPackage {}
+        function Get-AppxProvisionedPackage { param([switch]$Online) }
+        function Remove-AppxPackage { param([Parameter(ValueFromPipeline=$true)]$InputObject) }
+        function Remove-AppxProvisionedPackage { param([Parameter(ValueFromPipeline=$true)]$InputObject,[switch]$Online) }
+    }
+
+    It 'removes only non-whitelisted apps' {
+        Mock -CommandName Get-AppxPackage -MockWith {
+            @(
+                [pscustomobject]@{ Name = 'Microsoft.WindowsCalculator' },
+                [pscustomobject]@{ Name = 'Contoso.Bloatware' }
+            )
+        }
+        Mock -CommandName Get-AppxProvisionedPackage -MockWith { @() }
+        Mock -CommandName Remove-AppxPackage -MockWith {}
+        Mock -CommandName Remove-AppxProvisionedPackage -MockWith {}
+
+        DebloatAll
+
+        Assert-MockCalled Remove-AppxPackage -ParameterFilter { $InputObject.Name -eq 'Contoso.Bloatware' } -Times 2
+        Assert-MockCalled Remove-AppxPackage -ParameterFilter { $InputObject.Name -eq 'Microsoft.WindowsCalculator' } -Times 0
+    }
+}


### PR DESCRIPTION
## Summary
- add a DebloatAll unit test using Pester to ensure only non-whitelisted apps are removed

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Script tests/DebloatAll.Tests.ps1"`


------
https://chatgpt.com/codex/tasks/task_e_6896325b0cd0832b83f70fc1a7e5e3e4