### PR TITLE
fix: restore whitelisted apps reliably

### DIFF
--- a/Windows10Debloater.ps1
+++ b/Windows10Debloater.ps1
@@ -531,15 +531,21 @@ Function Enable-EdgePDF {
 }
 
 Function FixWhitelistedApps {
-    
-    If (!(Get-AppxPackage -AllUsers | Select Microsoft.Paint3D, Microsoft.WindowsCalculator, Microsoft.WindowsStore, Microsoft.Windows.Photos)) {
-    
-        #Credit to abulgatz for these 4 lines of code
-        Get-AppxPackage -allusers Microsoft.Paint3D | Foreach {Add-AppxPackage -DisableDevelopmentMode -Register "$($_.InstallLocation)\AppXManifest.xml"}
-        Get-AppxPackage -allusers Microsoft.WindowsCalculator | Foreach {Add-AppxPackage -DisableDevelopmentMode -Register "$($_.InstallLocation)\AppXManifest.xml"}
-        Get-AppxPackage -allusers Microsoft.WindowsStore | Foreach {Add-AppxPackage -DisableDevelopmentMode -Register "$($_.InstallLocation)\AppXManifest.xml"}
-        Get-AppxPackage -allusers Microsoft.Windows.Photos | Foreach {Add-AppxPackage -DisableDevelopmentMode -Register "$($_.InstallLocation)\AppXManifest.xml"} 
-    } 
+
+    $Apps = @(
+        "Microsoft.Paint3D",
+        "Microsoft.WindowsCalculator",
+        "Microsoft.WindowsStore",
+        "Microsoft.Windows.Photos"
+    )
+
+    foreach ($App in $Apps) {
+        if (-not (Get-AppxPackage -Name $App -ErrorAction SilentlyContinue)) {
+            Get-AppxPackage -AllUsers -Name $App | ForEach-Object {
+                Add-AppxPackage -DisableDevelopmentMode -Register "$($_.InstallLocation)\AppXManifest.xml"
+            }
+        }
+    }
 }
 
 Function UninstallOneDrive {


### PR DESCRIPTION
## Summary
- ensure `FixWhitelistedApps` reinstalls specific whitelisted apps when missing

## Testing
- `pwsh -NoLogo -Command '$PSVersionTable'`
- `pwsh -NoLogo -Command '[System.Management.Automation.PSParser]::Tokenize((Get-Content "Windows10Debloater.ps1" -Raw), [ref]$null) | Out-Null; "Syntax OK"'`


------
https://chatgpt.com/codex/tasks/task_e_68962fbefa80832bbd1f1ac2b4f02e6f